### PR TITLE
List boost-headers package as a dependency in an Android Termux envir…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ see what packages are left.
 'pkg install git'
 'pkg install build-essential'
 'pkg install exiv2'
-'pkg install boost'
+'pkg install boost-headers'
 python3 -m pip install -r requirements.txt
 ~~~
 


### PR DESCRIPTION
Documents the fix for issue #4. Termux changed the `boost` package to separate the headers out into the `boost-headers` package in https://github.com/termux/termux-packages/commit/0ddc5d9c46d08868c3b5a9cb876c88859b5f1ab2
