### PR TITLE
Fix bug in --copyall due to case insensitivity.

### DIFF
--- a/MotionPhotoMuxer.py
+++ b/MotionPhotoMuxer.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import sys
 from os.path import exists, basename, isdir
+import glob
 
 import pyexiv2
 
@@ -102,14 +103,10 @@ def convert(photo_path, video_path, output_path):
 def matching_video(photo_path):
     base = os.path.splitext(photo_path)[0]
     logging.info("Looking for videos named: {}".format(base))
-    if os.path.exists(base + ".mov"):
-        return base + ".mov"
-    if os.path.exists(base + ".mp4"):
-        return base + ".mp4"
-    if os.path.exists(base + ".MOV"):
-        return base + ".MOV"
-    if os.path.exists(base + ".MP4"):
-        return base + ".MP4"
+    files = set(glob.glob(base + ".*"))
+    for ext in (".mov", ".mp4", ".MOV", ".MP4"):
+        if base + ext in files:
+            return base + ext
     else:
         return ""
 


### PR DESCRIPTION
The matching_video function checks for videos with both lowercase and uppercase extensions. However, at least on my machine (WSL), os.path.exists returns true regardless of case. This works fine for converting the video. However, the --copyall logic is case sensitive, so you end up with a motion photo and a video when you should just have a motion photo.

The fix is to make matching_video return the file path in its original casing. As far as I can tell, the only way to do this is to first query the directory for its file names and then look for a match. os.path.realpath() and pathlib.Path.resolve() both seem to return the path in whatever casing you queried it with. I'm using glob here.